### PR TITLE
ci: remove recursive flag for isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           poetry run pylint linz_logger/**
       - name: Import Sorting
         run: |
-          poetry run isort -rc linz_logger/** --check --diff
+          poetry run isort linz_logger/** --check --diff
       - name: Test
         run: |
           poetry run pytest


### PR DESCRIPTION
As of `isort 5.0.0`, the `-rc` flag (recursive) is deprecated / redundant as this behaviour is now provided by default.