### PR TITLE
feat: replace threadlocal by contextvars

### DIFF
--- a/linz_logger/logger.py
+++ b/linz_logger/logger.py
@@ -36,6 +36,7 @@ def set_level(level: LogLevel):
     global current_level
     current_level = level
 
+
 def set_contextvars(key_value: dict):
     """Set the context variables.
 
@@ -44,6 +45,7 @@ def set_contextvars(key_value: dict):
     """
     bind_contextvars(**key_value)
 
+
 def remove_contextvars(keys):
     """Remove the context variables.
 
@@ -51,6 +53,7 @@ def remove_contextvars(keys):
         keys (list): A list of keys.
     """
     unbind_contextvars(*keys)
+
 
 def level_filter(_, __, event_dict: dict):
     """

--- a/linz_logger/logger.py
+++ b/linz_logger/logger.py
@@ -4,6 +4,7 @@ from enum import Enum
 from functools import partial
 
 import structlog
+from structlog.contextvars import bind_contextvars, clear_contextvars, merge_contextvars
 from structlog.exceptions import DropEvent
 
 
@@ -24,6 +25,7 @@ class LogLevel(Enum):
 
 
 current_level = LogLevel.debug
+clear_contextvars()
 
 
 def set_level(level: LogLevel):
@@ -33,6 +35,14 @@ def set_level(level: LogLevel):
     """
     global current_level
     current_level = level
+
+def set_contextvars(key_value: dict):
+    """_summary_
+
+    Args:
+        key_value (dict): _description_
+    """
+    bind_contextvars(**key_value)
 
 
 def level_filter(_, __, event_dict: dict):
@@ -76,13 +86,13 @@ def add_default_keys(current_logger, method_name: str, event_dict: dict):
 
 structlog.configure(
     processors=[
+        merge_contextvars,
         add_default_keys,
         level_filter,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.processors.JSONRenderer(),
-    ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
+    ]
 )
 
 

--- a/linz_logger/logger.py
+++ b/linz_logger/logger.py
@@ -4,7 +4,7 @@ from enum import Enum
 from functools import partial
 
 import structlog
-from structlog.contextvars import bind_contextvars, clear_contextvars, merge_contextvars
+from structlog.contextvars import bind_contextvars, clear_contextvars, merge_contextvars, unbind_contextvars
 from structlog.exceptions import DropEvent
 
 
@@ -37,13 +37,20 @@ def set_level(level: LogLevel):
     current_level = level
 
 def set_contextvars(key_value: dict):
-    """_summary_
+    """Set the context variables.
 
     Args:
-        key_value (dict): _description_
+        key_value (dict): A dictionnary of key-value pairs.
     """
     bind_contextvars(**key_value)
 
+def remove_contextvars(keys):
+    """Remove the context variables.
+
+    Args:
+        keys (list): A list of keys.
+    """
+    unbind_contextvars(*keys)
 
 def level_filter(_, __, event_dict: dict):
     """

--- a/linz_logger/test_logger.py
+++ b/linz_logger/test_logger.py
@@ -40,6 +40,7 @@ def test_timestamp(capsys):
 
     assert log["time"] - systime < 1000
 
+
 @pytest.mark.dependency()
 def test_set_contextvars(capsys):
     set_contextvars({"hostname": "localhost", "ip": "192.168.0.2"})
@@ -53,7 +54,8 @@ def test_set_contextvars(capsys):
     assert log["ip"] == "192.168.0.2"
     assert log["country"] == "NZ"
 
-@pytest.mark.dependency(depends=['test_set_contextvars'])
+
+@pytest.mark.dependency(depends=["test_set_contextvars"])
 def test_remove_contextvars(capsys):
     remove_contextvars(["hostname", "ip"])
 

--- a/linz_logger/test_logger.py
+++ b/linz_logger/test_logger.py
@@ -5,7 +5,7 @@ Tests for the hello() function.
 import json
 import os
 
-from .logger import LogLevel, get_log, set_level
+from .logger import LogLevel, get_log, set_contextvars, set_level
 
 
 def test_hello_without_name():
@@ -41,3 +41,15 @@ def test_timestamp(capsys):
     log = json.loads(stdout)
 
     assert log["time"] - systime < 1000
+
+def test_set_contextvars(capsys):
+    """Test """
+    set_contextvars({"hostname": "toto", "ip": "192.168.0.2"})
+    set_contextvars({"country": "NZ"})
+    get_log().trace("abc")
+    stdout, _ = capsys.readouterr()
+    log = json.loads(stdout)
+
+    assert log["hostname"] == "localhost"
+    assert log["ip"] == "192.168.0.2"
+    assert log["country"] == "NZ"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,6 +238,17 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-dependency"
+version = "0.5.1"
+description = "Manage dependencies of tests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 name = "structlog"
 version = "22.1.0"
 description = "Structured Logging for Python"
@@ -285,7 +296,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d75971459c7654057778182b771bf8bb611b38d59be10c3c8607cd6098bdf227"
+content-hash = "7de43d82ca56f04e095d22e15b6595bb09e531adac53753163ba34c9a46839b7"
 
 [metadata.files]
 astroid = []
@@ -388,6 +399,7 @@ pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
     {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
 ]
+pytest-dependency = []
 structlog = []
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ black = "^22.6.0"
 isort = "^5.10.1"
 pylint = "^2.14.5"
 pytest = "^7.1.2"
+pytest-dependency = "^0.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Description
Use of `threadlocal` [is deprecated](https://www.structlog.org/en/stable/thread-local.html?highlight=thread#legacy-thread-local-context) in `structlog` version `22.1.0`. Therefore, using contextvars allows to set some key-value for the current context.

## Changes
- Remove the possibility to use `threadlocal`
- Bind (`merge_contextvars`) the `contextvars` to the logger
- Expose `bind_contextvars` and `unbind_contextvars` methods