### PR TITLE
fix: Use specific action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
       - name: Setup Python 3.8

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3.5.0
         id: release
         with:
           release-type: python


### PR DESCRIPTION
GitHub Actions unfortunately runs the *latest* version of the actions which fits the `uses` directive version. So right now `actions/checkout@v3` is equivalent to `actions/checkout@v3.0.2`, but this can change at any time. To avoid workflows suddenly failing in case a new minor/patch version of an action, this PR uses the most specific version number available for the checkout action.