### PR TITLE
fix: Run workflows on a specific OS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,7 +6,7 @@ on:
 name: release-please
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
@@ -18,7 +18,7 @@ jobs:
 
   publish-release:
     needs: release-please
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - uses: actions/checkout@v3.1.0


### PR DESCRIPTION
Safer than running on a moving release.