### PR TITLE
fix: Allow some drift in timestamp test

### DIFF
--- a/linz_logger/test_logger.py
+++ b/linz_logger/test_logger.py
@@ -36,7 +36,7 @@ def test_timestamp(capsys):
     stdout, _ = capsys.readouterr()
     log = json.loads(stdout)
 
-    assert log["time"] - systime < 1000
+    assert -10000 < log["time"] - systime < 10000
 
 
 def test_contextvars(capsys):


### PR DESCRIPTION
It's easy for the two datetime-capturing lines to straddle a second boundary. And since the OS date is captured at second resolution, it's inevitable that sometimes the difference will be 1000 ms. To allow for this and any reasonably-sized interruption/leap second, I've changed the test to a 20-second window.

See for example [this job failure](https://github.com/linz/python-linz-logger/actions/runs/3623869777/jobs/6110213900).