### PR TITLE
fix: Don't attempt to install project inside virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install
         run: |
           pip install poetry
-          poetry install
+          poetry install --no-root
       - name: Format
         run: |
           poetry run black --check --diff linz_logger/*

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
         run: pip install poetry
 
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --no-root
 
       - name: Set PyPI token
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
We shouldn't need it for development purposes.